### PR TITLE
Set user_id with messages to bot

### DIFF
--- a/public/js/linesimulator.js
+++ b/public/js/linesimulator.js
@@ -572,7 +572,7 @@ function sendTextMessage(text, displayOnly) {
     "timestamp": 1462629479859,
     "source": {
       "type": "user",
-      "userId": userId
+      "userId": "U1234567890abcdef01234567890abcde"
     },
     "message": {
       "id": "325708",


### PR DESCRIPTION
Currently the `userId` parameter is blank in messages sent to the bot via the simulator. For testing, it would be better if this was set to something. I used an value obviously dummy value to make debugging easier.