### PR TITLE
Add member events

### DIFF
--- a/public/js/linesimulator.js
+++ b/public/js/linesimulator.js
@@ -722,6 +722,57 @@ function sendBeacon() {
 
   send(sendObject);
 }
+function sendMemberJoined() {
+  // Craft LINE message
+  var sendObject = {
+    "replyToken": "0f3779fba3b349968c5d07db31eabf65",
+    "type": "memberJoined",
+    "timestamp": 1462629479859,
+    "source": {
+      "type": "group",
+      "groupId": "C4af4980629..."
+    },
+    "joined": {
+      "members": [
+        {
+          "type": "user",
+          "userId": "U4af4980629..."
+        },
+        {
+          "type": "user",
+          "userId": "U91eeaf62d9..."
+        }
+      ]
+    }
+  }
+
+  send(sendObject);
+}
+function sendMemberLeft() {
+  // Craft LINE message
+  var sendObject = {
+    "type": "memberLeft",
+    "timestamp": 1462629479960,
+    "source": {
+      "type": "group",
+      "groupId": "C4af4980629..."
+    },
+    "left": {
+      "members": [
+        {
+          "type": "user",
+          "userId": "U4af4980629..."
+        },
+        {
+          "type": "user",
+          "userId": "U91eeaf62d9..."
+        }
+      ]
+    }
+  }
+
+  send(sendObject);
+}
 //#endregion
 
 //#region Send data as Bot (POC features)

--- a/simulator.html
+++ b/simulator.html
@@ -180,10 +180,12 @@
             <div class="row">
                 <h4>System Messages</h4>
                 <div class="col-md-12">
-                    <a class="btn btn-primary" onclick="sendFollow()">Follow</a>
-                    <a class="btn btn-primary" onclick="sendUnfollow()">Unfollow</a>
-                    <a class="btn btn-primary" onclick="sendJoin()">Join</a>
-                    <a class="btn btn-primary" onclick="sendLeave()">Leave</a>
+                    <a class="btn btn-sm btn-primary" onclick="sendFollow()">Follow</a>
+                    <a class="btn btn-sm btn-primary" onclick="sendUnfollow()">Unfollow</a>
+                    <a class="btn btn-sm btn-primary" onclick="sendJoin()">Join</a>
+                    <a class="btn btn-sm btn-primary" onclick="sendLeave()">Leave</a>
+                    <a class="btn btn-sm btn-primary" onclick="sendMemberJoined()">MemberJoined</a>
+                    <a class="btn btn-sm btn-primary" onclick="sendMemberLeft()">MemberLeft</a>
                 </div>
             </div>
             <div class="row">


### PR DESCRIPTION
There are two webhooks, `memberJoined` and `memberLeft`, which are not currently supported by the simulator. This PR adds them.