### PR TITLE
Fix bugs for carousel MessageAction to show label

### DIFF
--- a/public/js/linesimulator.js
+++ b/public/js/linesimulator.js
@@ -355,7 +355,7 @@ function parseDataAndReturnListItem(data) {
             }
           }
           else if (action.type == "message") {
-            reply += `<div class="chat-template-buttons-button" onclick="{sendTextMessage('${action.text}');}">${action.text}</div>`;
+            reply += `<div class="chat-template-buttons-button" onclick="{sendTextMessage('${action.text}');}">${action.label}</div>`;
           }
           else if (action.type == "uri") {
             reply += `<div class="chat-template-buttons-button"><a href="${action.uri}" target="_blank">${action.label}</a></div>`;


### PR DESCRIPTION
In carousel template with message action, in the html it shows action.text instead of action.label. This commit change the html to show action.label instead of action.text